### PR TITLE
chore: update to 0.25.2 and modify names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "readme-tutorial-testing",
-  "version": "0.25.0-dev",
+  "version": "0.25.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "readme-tutorial-testing",
-      "version": "0.25.0-dev",
+      "version": "0.25.2",
       "license": "MIT",
       "dependencies": {
-        "@dashevo/wasm-dpp": "^0.25.0-dev.32",
-        "dash": "^3.25.0-dev.32"
+        "@dashevo/wasm-dpp": "^0.25.2",
+        "dash": "^3.25.2"
       },
       "devDependencies": {
-        "chai": "^4.3.7",
+        "chai": "^4.3.10",
         "dotenv": "^16.0.0",
-        "eslint": "^8.46.0",
+        "eslint": "^8.50.0",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-plugin-import": "^2.28.0",
+        "eslint-plugin-import": "^2.28.1",
         "faker": "5.5.3",
         "mocha": "^10.2.0"
       }
@@ -50,31 +50,75 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dependencies": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -125,9 +169,9 @@
       }
     },
     "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -151,31 +195,32 @@
       }
     },
     "node_modules/@dashevo/dapi-client": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.25.0-dev.32.tgz",
-      "integrity": "sha512-NHa9j4D4Ss4tvCUb4TZKKStPpwTucOym2WsrVcxpp1v5SJKYp8sOK3uChZc1pQ6c47pPBRQJECTnNHX3evYigg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.25.2.tgz",
+      "integrity": "sha512-hmjcodjLDABTvqMwOFXwTw38BSLueESNNBof/h++6kNbQhM4hb6Md18XD7mn7M1F5FSCMaxWELqb9WQFahuFhQ==",
       "dependencies": {
-        "@dashevo/dapi-grpc": "0.25.0-dev.32",
-        "@dashevo/dash-spv": "0.25.0-dev.32",
+        "@dashevo/dapi-grpc": "0.25.2",
+        "@dashevo/dash-spv": "0.25.2",
         "@dashevo/dashcore-lib": "~0.20.9",
-        "@dashevo/dpp": "0.25.0-dev.32",
-        "@dashevo/grpc-common": "0.25.0-dev.32",
-        "@dashevo/wasm-dpp": "0.25.0-dev.32",
+        "@dashevo/dpp": "0.25.2",
+        "@dashevo/grpc-common": "0.25.2",
+        "@dashevo/wasm-dpp": "0.25.2",
         "bs58": "^4.0.1",
         "cbor": "^8.0.0",
         "google-protobuf": "^3.12.2",
         "lodash": "^4.17.21",
         "node-fetch": "^2.6.7",
         "node-inspect-extracted": "^1.0.8",
-        "wasm-x11-hash": "~0.0.2"
+        "wasm-x11-hash": "~0.0.2",
+        "winston": "^3.2.1"
       }
     },
     "node_modules/@dashevo/dapi-grpc": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.25.0-dev.32.tgz",
-      "integrity": "sha512-updLHX10D2Qcq3FE/N0UUWZs3ngT/fvDPFawfHCTfmJPGJ8aNH7GjQkBrkoqgGm56n7NXOPiHYCvxG7mMKQ0eA==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.25.2.tgz",
+      "integrity": "sha512-siOWMiK7o3BpRzXpR7KMqJVKu0GMt7vUE5m35gbkW3QwZuoAbcHKivlL04RpxssuVHRtK9jtENcdisNIjuX4UA==",
       "dependencies": {
-        "@dashevo/grpc-common": "0.25.0-dev.32",
+        "@dashevo/grpc-common": "0.25.2",
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "^1.3.7",
         "@improbable-eng/grpc-web": "^0.15.0",
@@ -189,9 +234,9 @@
       "integrity": "sha512-rt0PzGzqplqERWVIMLlBxm4mJqjFTYNUFRhIccbfaF/MDyd0/585krGOWIhe0Sis9XQNA/FJlxxRjtPXIcyyCg=="
     },
     "node_modules/@dashevo/dash-spv": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-0.25.0-dev.32.tgz",
-      "integrity": "sha512-YlbDki2lVQmgs6VNFaRKLqA5PO+HMYOGidv3a8lIAVJHRz+GjVOA1VVW2oTeXGBsT46B3mNz7NzKlD2CJyLSyg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-0.25.2.tgz",
+      "integrity": "sha512-yrlU/h1SMkF4fZfiDCX7zWAZS93M1g/0QhWwKKgDw+cM+D6eBp4yy+tLWAzVEVhLCy6J4Ya3XpmnuWd2w40Piw==",
       "dependencies": {
         "@dashevo/dark-gravity-wave": "^1.1.1",
         "@dashevo/dash-util": "^2.0.3",
@@ -235,27 +280,27 @@
       "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
     },
     "node_modules/@dashevo/dashpay-contract": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-0.25.0-dev.32.tgz",
-      "integrity": "sha512-UCn1LJtXC5wWHYqpRi4NxxKKz3JPR0bC8AgREV3no+b2rSaBHxj+wDyNLvbhXFmKCVmKW6MiZrz1Tkf8hpJ9Hg=="
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-0.25.2.tgz",
+      "integrity": "sha512-s4vNfacWuXC45of/P3W5Mm8Q6tFQH94OxKgIUfP5W1PwYwzDw1VI04oX+rz7qmMTcvFdukZ8KQAO4lNs9YBpzg=="
     },
     "node_modules/@dashevo/dpns-contract": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-0.25.0-dev.32.tgz",
-      "integrity": "sha512-6GXmQPibl/tGWiK4uURi9kilmhTqYQRovc7rHqNYtzH1haOmx+gyKmF52PG+C0RpebYJJlvllOgz2ivLz+KXWQ=="
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-0.25.2.tgz",
+      "integrity": "sha512-IZdQt1KZdCUSZwSfGpiukUA8VFXRtkfgPnOOn33b2i8421gAtvdVGX24hJL1n5liy9Kn5DP29U9UfZevUp1ZwQ=="
     },
     "node_modules/@dashevo/dpp": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.25.0-dev.32.tgz",
-      "integrity": "sha512-RRoU9LMNN3vMpKL8sefXmokrol/oOXY2HQC0cYEhB/xx4MYgKpARuYD/qvXEkN6xr6AfL/Rf6dzW+eO5+Lfu9Q==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.25.2.tgz",
+      "integrity": "sha512-VHBZjRQQSZkPENBNhNk7k/56vzE/LNaDAO4OQJm55TsnI5+eBclj/EL8T6cWoq/2EZEOFCL3TBx61ukb8zMEAQ==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
         "@dashevo/bls": "~1.2.9",
         "@dashevo/dashcore-lib": "~0.20.9",
-        "@dashevo/dashpay-contract": "0.25.0-dev.32",
-        "@dashevo/dpns-contract": "0.25.0-dev.32",
-        "@dashevo/feature-flags-contract": "0.25.0-dev.32",
-        "@dashevo/masternode-reward-shares-contract": "0.25.0-dev.32",
+        "@dashevo/dashpay-contract": "0.25.2",
+        "@dashevo/dpns-contract": "0.25.2",
+        "@dashevo/feature-flags-contract": "0.25.2",
+        "@dashevo/masternode-reward-shares-contract": "0.25.2",
         "@dashevo/wasm-re2": "~2.0.4",
         "ajv": "^8.6.0",
         "ajv-formats": "^2.1.1",
@@ -271,9 +316,9 @@
       }
     },
     "node_modules/@dashevo/dpp/node_modules/ajv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
-      "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -291,14 +336,14 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@dashevo/feature-flags-contract": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/feature-flags-contract/-/feature-flags-contract-0.25.0-dev.32.tgz",
-      "integrity": "sha512-x3vFnPp3khjgAv2wAetd2xx94HTmDkeX2eyesCcQFCRbSExtUdxAdCezFWtHriYzonk3mjwZRjN6ypQWK8Fwmg=="
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/feature-flags-contract/-/feature-flags-contract-0.25.2.tgz",
+      "integrity": "sha512-boM7lGgUmwu1p7B6MMl3uA+su368ibCraoaExi3kAKPKfimbToYaMF3un+WD+qe/ja8Au1P1gcEkiFZlzoskDg=="
     },
     "node_modules/@dashevo/grpc-common": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.25.0-dev.32.tgz",
-      "integrity": "sha512-yopYborud2ByA+tHHeFKiNQf0ezRPvDr/+KATqUeZ66p5DYISoJbOVp+SxBo85LenU1ksUEzro440WJ3Tqo54g==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.25.2.tgz",
+      "integrity": "sha512-M3KgMpBC0hhbwcZp7PkB4mOblqtliNZ25IKHlBoyE82oAQDvRDYRrs1Yzry5twSyJ8cgORKHbGOP/ROdcs74ZA==",
       "dependencies": {
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "^1.3.7",
@@ -310,9 +355,9 @@
       }
     },
     "node_modules/@dashevo/masternode-reward-shares-contract": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-0.25.0-dev.32.tgz",
-      "integrity": "sha512-y+ulCaJJIc4D/2RfUi0N5Z1VJimyoUq5qhMOmbb9FQnwaHvOouaMIfSF5+mAgMZi9SZcjSApeJaQQhgi7pVTQA=="
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-0.25.2.tgz",
+      "integrity": "sha512-grfJoO2UsPx5Va5quWheZa/rNi2tcXu4vVpt/YhUKepkzeg5Yon873e5+HffxBg12BS7gxI+2PAwUrOqq7OovQ=="
     },
     "node_modules/@dashevo/protobufjs": {
       "version": "6.10.5",
@@ -350,14 +395,14 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/@dashevo/wallet-lib": {
-      "version": "7.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-7.25.0-dev.32.tgz",
-      "integrity": "sha512-TqfeV6xILk77Sh+9emMucGtL43TwKKXtDY7TsnK6Kji+lF/W2B1ZhXihWqis0ANCaZpGKEQJGE764DXAuPnzpw==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-7.25.2.tgz",
+      "integrity": "sha512-3SeDgy7TEswhQ84ni7khGu6utUCzCKzt0PekyTQRNAI/I6dsrfpSz/D/XYRNdhl+MLpOxz8FKlWP550spuviQQ==",
       "dependencies": {
-        "@dashevo/dapi-client": "0.25.0-dev.32",
+        "@dashevo/dapi-client": "0.25.2",
         "@dashevo/dashcore-lib": "~0.20.9",
-        "@dashevo/grpc-common": "0.25.0-dev.32",
-        "@dashevo/wasm-dpp": "0.25.0-dev.32",
+        "@dashevo/grpc-common": "0.25.2",
+        "@dashevo/wasm-dpp": "0.25.2",
         "@yarnpkg/pnpify": "^4.0.0-rc.42",
         "cbor": "^8.0.0",
         "crypto-js": "^4.0.0",
@@ -368,9 +413,9 @@
       }
     },
     "node_modules/@dashevo/wasm-dpp": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-0.25.0-dev.32.tgz",
-      "integrity": "sha512-q6t/K4pLXC0faCmOKKGwssNE9t28FLx0MuT2omAXeiMVXdRwi1feL/zcm41gbbqeaOhumKYQd/93Lb6Yl0PWxQ==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-0.25.2.tgz",
+      "integrity": "sha512-+EECBDbdhmKFMqTcYic0BkbS9VPTK3coyjBbYK/PNwOs6+FZDPkXj751ntlUpbRf+lzG8b1JHrS7rWg2ej1h3w==",
       "dependencies": {
         "@dashevo/bls": "~1.2.9",
         "bs58": "^4.0.1",
@@ -466,9 +511,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.4.tgz",
-      "integrity": "sha512-oEnzYiDuEsBydZBtP84BkpduLsE1nSAO4KrhTLHRzNrIQE647fhchmosTQsJdCo8X9zBBt+l5+fNk+m/yCFJ/Q==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.5.tgz",
+      "integrity": "sha512-iouYNlPxRAwZ2XboDT+OfRKHuaKHiqjB5VFYZ0NFrHkbEF+AV3muIUY9olQsp8uxU4VvRCMiRk9ftzFDGb61aw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -495,9 +540,12 @@
       }
     },
     "node_modules/@grpc/grpc-js/node_modules/@types/node": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.0.tgz",
-      "integrity": "sha512-LzcWltT83s1bthcvjBmiBvGJiiUe84NWRHkw+ZV6Fr41z2FbIzvc815dk2nQ3RAKMuN2fkenM/z3Xv2QzEpYxQ=="
+      "version": "20.8.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
+      "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
     },
     "node_modules/@grpc/grpc-js/node_modules/cliui": {
       "version": "8.0.1",
@@ -617,11 +665,11 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dependencies": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -719,9 +767,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.24",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -776,9 +824,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.2",
@@ -786,9 +834,9 @@
       "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw=="
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -810,9 +858,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/minimist": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.3.tgz",
+      "integrity": "sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A=="
     },
     "node_modules/@types/node": {
       "version": "12.20.55",
@@ -820,9 +868,9 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "node_modules/@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
+      "integrity": "sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A=="
     },
     "node_modules/@types/responselike": {
       "version": "1.0.1",
@@ -848,17 +896,17 @@
       "integrity": "sha512-6tOUG+nVHn0cJbVp25JFayS5UE6+xlbcNF9Lo9mU7U0zk3zeUShZied4YEQZjy1JBF043FSkdXw8YkUJuVtB5g=="
     },
     "node_modules/@yarnpkg/core": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.0.0-rc.52.tgz",
-      "integrity": "sha512-qzFPXsRWMdgUNZYPl5kLhYQbGnnyfAnC/TDIsAeR0Nt9rLkq/cCXRA5aRgDejAHZJzJeB1XjncuR4C9B+LcBbg==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.0.0-rc.53.tgz",
+      "integrity": "sha512-juQC2CCUJE6xu/fpIWrviFzjZO87sxTu9T4C79g2UIjtC2A5mOx35nlk3VcennA41nG8VGqpttbE2YQtuzvpvg==",
       "dependencies": {
         "@arcanis/slice-ansi": "^1.1.1",
         "@types/semver": "^7.1.0",
         "@types/treeify": "^1.0.0",
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
-        "@yarnpkg/libzip": "^3.0.0-rc.52",
-        "@yarnpkg/parsers": "^3.0.0-rc.52",
-        "@yarnpkg/shell": "^4.0.0-rc.52",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
+        "@yarnpkg/libzip": "^3.0.0-rc.53",
+        "@yarnpkg/parsers": "^3.0.0-rc.53",
+        "@yarnpkg/shell": "^4.0.0-rc.53",
         "camelcase": "^5.3.1",
         "chalk": "^3.0.0",
         "ci-info": "^3.2.0",
@@ -948,9 +996,9 @@
       }
     },
     "node_modules/@yarnpkg/fslib": {
-      "version": "3.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-3.0.0-rc.52.tgz",
-      "integrity": "sha512-zPyVCOzWCxQUe41AYyS8lTDXhg1hAB8XQ49sT7JFW8cU/8wPVa/YAHwcQ210uiKI9P7PsjK0a35jmc7V40Feuw==",
+      "version": "3.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-3.0.0-rc.53.tgz",
+      "integrity": "sha512-raT6iG2MgCulPF/f0UHv3EdXAIXi/5ZtQCT5IHsDdpn7VrhusA8c7Y9WnD03Od2lfXj4C8kNnLoB0OXM9rLmRg==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -959,38 +1007,38 @@
       }
     },
     "node_modules/@yarnpkg/libzip": {
-      "version": "3.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-3.0.0-rc.52.tgz",
-      "integrity": "sha512-RCxm4a1m/Hn2QzSm0+xgyy975pTQnamV+Knu3U/2WX9SSTzytY+tH1PECrLaK7bHiGG9etP3yFdk8fJXADu86g==",
+      "version": "3.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-3.0.0-rc.53.tgz",
+      "integrity": "sha512-dzSkQDg5KMqdC8PE3p57Qr6auIjWGbAP6k+M6gCLOho9zOpmzRGNXJHqN3sqFN43WxPmIZ65faY3yDXDgxHqNg==",
       "dependencies": {
         "@types/emscripten": "^1.39.6",
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
         "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "@yarnpkg/fslib": "^3.0.0-rc.52"
+        "@yarnpkg/fslib": "^3.0.0-rc.53"
       }
     },
     "node_modules/@yarnpkg/nm": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/nm/-/nm-4.0.0-rc.52.tgz",
-      "integrity": "sha512-2Wgu9apCWRdhV3fKXAAc3opmTikkZbmsCFs0TR6yozisVayc2yAETlL+AMZ8l9xmw1RBH1dOItmvfDLx1c+++A==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/nm/-/nm-4.0.0-rc.53.tgz",
+      "integrity": "sha512-W1tdoJF2CKUQJ6YoaUQ+NT2yGOFMsGNdxyqRrHzm3xV22RNIuNm2p3Gr2cjTu13OfstJj9i87aMJiyxbagLxCQ==",
       "dependencies": {
-        "@yarnpkg/core": "^4.0.0-rc.52",
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
-        "@yarnpkg/pnp": "^4.0.0-rc.52"
+        "@yarnpkg/core": "^4.0.0-rc.53",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
+        "@yarnpkg/pnp": "^4.0.0-rc.53"
       },
       "engines": {
         "node": ">=18.12.0"
       }
     },
     "node_modules/@yarnpkg/parsers": {
-      "version": "3.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.52.tgz",
-      "integrity": "sha512-b1V4J/tQ8Hj0NalU6EXcYhQcgJqVEz2CgKkoO3suZe7HJlZqrFD2Q9+1vBNbsXAaLqHGVcF0JwRyTRhMT3MJkg==",
+      "version": "3.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.53.tgz",
+      "integrity": "sha512-kprOp3hV9l7B9oqjgTQIM04mmEaYBYcccUXVIM1NFFf10HqnD9joTfZ1cAqx9lpccWzgUnHkrhVwhhlGjPzyIw==",
       "dependencies": {
         "js-yaml": "^3.10.0",
         "tslib": "^2.4.0"
@@ -1000,30 +1048,30 @@
       }
     },
     "node_modules/@yarnpkg/pnp": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-4.0.0-rc.52.tgz",
-      "integrity": "sha512-ihUs4QdFc4LGqozxxlAQSjk4z4bt1xnWLTPcZ2gv6tyVv6TAeA7hMVinFiJsp9WMFxARPB20Q+72cAZ0C7jJIg==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-4.0.0-rc.53.tgz",
+      "integrity": "sha512-qTn/F/pMRjOggAWcF2Fbwub3BvBKFQJoDC8jv7N4RQOdtUPhMUPq/PQ/iwVEb0Owed+Pt23WKM0CHvED63lLBA==",
       "dependencies": {
         "@types/node": "^18.17.15",
-        "@yarnpkg/fslib": "^3.0.0-rc.52"
+        "@yarnpkg/fslib": "^3.0.0-rc.53"
       },
       "engines": {
         "node": ">=18.12.0"
       }
     },
     "node_modules/@yarnpkg/pnp/node_modules/@types/node": {
-      "version": "18.18.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.1.tgz",
-      "integrity": "sha512-3G42sxmm0fF2+Vtb9TJQpnjmP+uKlWvFa8KoEGquh4gqRmoUG/N0ufuhikw6HEsdG2G2oIKhog1GCTfz9v5NdQ=="
+      "version": "18.18.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.4.tgz",
+      "integrity": "sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ=="
     },
     "node_modules/@yarnpkg/pnpify": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/pnpify/-/pnpify-4.0.0-rc.52.tgz",
-      "integrity": "sha512-huNVHozWCsYwUV/Ts0pFEUVmkqeFCK2tWRWc5gJxlTqf8LLhZ7C8Tm/CqN/qxta6n/blqrFX8JNhB035RZ+MAw==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnpify/-/pnpify-4.0.0-rc.53.tgz",
+      "integrity": "sha512-RZ2yl4Ko+Wb+YIfjmukTwZ0GH436GEuTntXS91s49Jl/C6wZZJ0ve6n8PDd7Wwf2E2ubsDgotlgiv3MrdesSsw==",
       "dependencies": {
-        "@yarnpkg/core": "^4.0.0-rc.52",
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
-        "@yarnpkg/nm": "^4.0.0-rc.52",
+        "@yarnpkg/core": "^4.0.0-rc.53",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
+        "@yarnpkg/nm": "^4.0.0-rc.53",
         "clipanion": "^4.0.0-rc.2",
         "tslib": "^2.4.0"
       },
@@ -1035,12 +1083,12 @@
       }
     },
     "node_modules/@yarnpkg/shell": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/shell/-/shell-4.0.0-rc.52.tgz",
-      "integrity": "sha512-ydSqKU0fFzYoR6mSYr34EM9p5dH7sP2aaMidpRLe5k3RuqykqzIakewcg1hsyvkNsgLOAc1HSbBk2IX9u45RlA==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/shell/-/shell-4.0.0-rc.53.tgz",
+      "integrity": "sha512-Jjr9ljA8bBGNawQJGVClgR+g/UtuXv47F2gRMiGMYXtyvQpQBC7JHNilIS9dd7y8k6e5AV+JKUPnOOKJd1+EjA==",
       "dependencies": {
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
-        "@yarnpkg/parsers": "^3.0.0-rc.52",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
+        "@yarnpkg/parsers": "^3.0.0-rc.53",
         "chalk": "^3.0.0",
         "clipanion": "^4.0.0-rc.2",
         "cross-spawn": "7.0.3",
@@ -1166,9 +1214,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -1442,9 +1490,9 @@
       ]
     },
     "node_modules/bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "engines": {
         "node": "*"
       }
@@ -1582,9 +1630,9 @@
       }
     },
     "node_modules/call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1617,6 +1665,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cbor": {
@@ -1735,9 +1791,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "funding": [
         {
           "type": "github",
@@ -1886,21 +1942,21 @@
       "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/dash": {
-      "version": "3.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/dash/-/dash-3.25.0-dev.32.tgz",
-      "integrity": "sha512-Phj7sX38VL95vtFtcmvP2x5xEYn3B1QHFrYWvsyC1AWXALvwhBKbrHNA8LL9/Z6CM7QpFmOHHlRpzobGk2MpDA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/dash/-/dash-3.25.2.tgz",
+      "integrity": "sha512-sckKpCcHmfPNhvnSHRBbTd1y2tYsoPCXj5zUnBl6Ajlw68rNpwp/T35Ms0HjOHiuXX3NvtFfIQC3282BSOqHlQ==",
       "dependencies": {
         "@dashevo/bls": "~1.2.9",
-        "@dashevo/dapi-client": "0.25.0-dev.32",
-        "@dashevo/dapi-grpc": "0.25.0-dev.32",
+        "@dashevo/dapi-client": "0.25.2",
+        "@dashevo/dapi-grpc": "0.25.2",
         "@dashevo/dashcore-lib": "~0.20.9",
-        "@dashevo/dashpay-contract": "0.25.0-dev.32",
-        "@dashevo/dpns-contract": "0.25.0-dev.32",
-        "@dashevo/dpp": "0.25.0-dev.32",
-        "@dashevo/grpc-common": "0.25.0-dev.32",
-        "@dashevo/masternode-reward-shares-contract": "0.25.0-dev.32",
-        "@dashevo/wallet-lib": "7.25.0-dev.32",
-        "@dashevo/wasm-dpp": "0.25.0-dev.32",
+        "@dashevo/dashpay-contract": "0.25.2",
+        "@dashevo/dpns-contract": "0.25.2",
+        "@dashevo/dpp": "0.25.2",
+        "@dashevo/grpc-common": "0.25.2",
+        "@dashevo/masternode-reward-shares-contract": "0.25.2",
+        "@dashevo/wallet-lib": "7.25.2",
+        "@dashevo/wasm-dpp": "0.25.2",
         "bs58": "^4.0.1",
         "node-inspect-extracted": "^1.0.8",
         "winston": "^3.2.1"
@@ -2049,9 +2105,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -2140,11 +2196,6 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "node_modules/error-ex/node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/es-abstract": {
       "version": "1.22.1",
@@ -2620,9 +2671,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2743,9 +2794,9 @@
       }
     },
     "node_modules/foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -3162,17 +3213,6 @@
         "node": ">=10.19.0"
       }
     },
-    "node_modules/http2-wrapper/node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3290,9 +3330,9 @@
       }
     },
     "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -3562,23 +3602,23 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/jest-diff": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
-      "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.4.3",
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.5.0"
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-get-type": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
-      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3633,7 +3673,7 @@
     "node_modules/json-schema-diff-validator/node_modules/fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
     },
     "node_modules/json-schema-diff-validator/node_modules/fast-json-patch": {
       "version": "2.2.1",
@@ -3671,9 +3711,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -3823,10 +3863,18 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "node_modules/logform/node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/loupe": {
       "version": "2.3.6",
@@ -4556,11 +4604,11 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -4594,9 +4642,12 @@
       }
     },
     "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.0.tgz",
-      "integrity": "sha512-LzcWltT83s1bthcvjBmiBvGJiiUe84NWRHkw+ZV6Fr41z2FbIzvc815dk2nQ3RAKMuN2fkenM/z3Xv2QzEpYxQ=="
+      "version": "20.8.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
+      "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
     },
     "node_modules/protobufjs/node_modules/long": {
       "version": "4.0.0",
@@ -4645,11 +4696,14 @@
       ]
     },
     "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/randombytes": {
@@ -4769,9 +4823,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -4785,9 +4839,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5007,9 +5061,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5087,6 +5141,11 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5119,14 +5178,14 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w=="
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
+      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw=="
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -5511,6 +5570,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+    },
     "node_modules/unorm": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
@@ -5615,11 +5679,11 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
-      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+      "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
       "dependencies": {
-        "@colors/colors": "1.5.0",
+        "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
@@ -5821,25 +5885,59 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "requires": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ=="
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
     },
     "@babel/highlight": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
@@ -5877,9 +5975,9 @@
       }
     },
     "@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
     },
     "@dabh/diagnostics": {
       "version": "2.0.3",
@@ -5900,31 +5998,32 @@
       }
     },
     "@dashevo/dapi-client": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.25.0-dev.32.tgz",
-      "integrity": "sha512-NHa9j4D4Ss4tvCUb4TZKKStPpwTucOym2WsrVcxpp1v5SJKYp8sOK3uChZc1pQ6c47pPBRQJECTnNHX3evYigg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.25.2.tgz",
+      "integrity": "sha512-hmjcodjLDABTvqMwOFXwTw38BSLueESNNBof/h++6kNbQhM4hb6Md18XD7mn7M1F5FSCMaxWELqb9WQFahuFhQ==",
       "requires": {
-        "@dashevo/dapi-grpc": "0.25.0-dev.32",
-        "@dashevo/dash-spv": "0.25.0-dev.32",
+        "@dashevo/dapi-grpc": "0.25.2",
+        "@dashevo/dash-spv": "0.25.2",
         "@dashevo/dashcore-lib": "~0.20.9",
-        "@dashevo/dpp": "0.25.0-dev.32",
-        "@dashevo/grpc-common": "0.25.0-dev.32",
-        "@dashevo/wasm-dpp": "0.25.0-dev.32",
+        "@dashevo/dpp": "0.25.2",
+        "@dashevo/grpc-common": "0.25.2",
+        "@dashevo/wasm-dpp": "0.25.2",
         "bs58": "^4.0.1",
         "cbor": "^8.0.0",
         "google-protobuf": "^3.12.2",
         "lodash": "^4.17.21",
         "node-fetch": "^2.6.7",
         "node-inspect-extracted": "^1.0.8",
-        "wasm-x11-hash": "~0.0.2"
+        "wasm-x11-hash": "~0.0.2",
+        "winston": "^3.2.1"
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.25.0-dev.32.tgz",
-      "integrity": "sha512-updLHX10D2Qcq3FE/N0UUWZs3ngT/fvDPFawfHCTfmJPGJ8aNH7GjQkBrkoqgGm56n7NXOPiHYCvxG7mMKQ0eA==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.25.2.tgz",
+      "integrity": "sha512-siOWMiK7o3BpRzXpR7KMqJVKu0GMt7vUE5m35gbkW3QwZuoAbcHKivlL04RpxssuVHRtK9jtENcdisNIjuX4UA==",
       "requires": {
-        "@dashevo/grpc-common": "0.25.0-dev.32",
+        "@dashevo/grpc-common": "0.25.2",
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "^1.3.7",
         "@improbable-eng/grpc-web": "^0.15.0",
@@ -5938,9 +6037,9 @@
       "integrity": "sha512-rt0PzGzqplqERWVIMLlBxm4mJqjFTYNUFRhIccbfaF/MDyd0/585krGOWIhe0Sis9XQNA/FJlxxRjtPXIcyyCg=="
     },
     "@dashevo/dash-spv": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-0.25.0-dev.32.tgz",
-      "integrity": "sha512-YlbDki2lVQmgs6VNFaRKLqA5PO+HMYOGidv3a8lIAVJHRz+GjVOA1VVW2oTeXGBsT46B3mNz7NzKlD2CJyLSyg==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dash-spv/-/dash-spv-0.25.2.tgz",
+      "integrity": "sha512-yrlU/h1SMkF4fZfiDCX7zWAZS93M1g/0QhWwKKgDw+cM+D6eBp4yy+tLWAzVEVhLCy6J4Ya3XpmnuWd2w40Piw==",
       "requires": {
         "@dashevo/dark-gravity-wave": "^1.1.1",
         "@dashevo/dash-util": "^2.0.3",
@@ -5986,27 +6085,27 @@
       }
     },
     "@dashevo/dashpay-contract": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-0.25.0-dev.32.tgz",
-      "integrity": "sha512-UCn1LJtXC5wWHYqpRi4NxxKKz3JPR0bC8AgREV3no+b2rSaBHxj+wDyNLvbhXFmKCVmKW6MiZrz1Tkf8hpJ9Hg=="
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashpay-contract/-/dashpay-contract-0.25.2.tgz",
+      "integrity": "sha512-s4vNfacWuXC45of/P3W5Mm8Q6tFQH94OxKgIUfP5W1PwYwzDw1VI04oX+rz7qmMTcvFdukZ8KQAO4lNs9YBpzg=="
     },
     "@dashevo/dpns-contract": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-0.25.0-dev.32.tgz",
-      "integrity": "sha512-6GXmQPibl/tGWiK4uURi9kilmhTqYQRovc7rHqNYtzH1haOmx+gyKmF52PG+C0RpebYJJlvllOgz2ivLz+KXWQ=="
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpns-contract/-/dpns-contract-0.25.2.tgz",
+      "integrity": "sha512-IZdQt1KZdCUSZwSfGpiukUA8VFXRtkfgPnOOn33b2i8421gAtvdVGX24hJL1n5liy9Kn5DP29U9UfZevUp1ZwQ=="
     },
     "@dashevo/dpp": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.25.0-dev.32.tgz",
-      "integrity": "sha512-RRoU9LMNN3vMpKL8sefXmokrol/oOXY2HQC0cYEhB/xx4MYgKpARuYD/qvXEkN6xr6AfL/Rf6dzW+eO5+Lfu9Q==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.25.2.tgz",
+      "integrity": "sha512-VHBZjRQQSZkPENBNhNk7k/56vzE/LNaDAO4OQJm55TsnI5+eBclj/EL8T6cWoq/2EZEOFCL3TBx61ukb8zMEAQ==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
         "@dashevo/bls": "~1.2.9",
         "@dashevo/dashcore-lib": "~0.20.9",
-        "@dashevo/dashpay-contract": "0.25.0-dev.32",
-        "@dashevo/dpns-contract": "0.25.0-dev.32",
-        "@dashevo/feature-flags-contract": "0.25.0-dev.32",
-        "@dashevo/masternode-reward-shares-contract": "0.25.0-dev.32",
+        "@dashevo/dashpay-contract": "0.25.2",
+        "@dashevo/dpns-contract": "0.25.2",
+        "@dashevo/feature-flags-contract": "0.25.2",
+        "@dashevo/masternode-reward-shares-contract": "0.25.2",
         "@dashevo/wasm-re2": "~2.0.4",
         "ajv": "^8.6.0",
         "ajv-formats": "^2.1.1",
@@ -6022,9 +6121,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
-          "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -6040,14 +6139,14 @@
       }
     },
     "@dashevo/feature-flags-contract": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/feature-flags-contract/-/feature-flags-contract-0.25.0-dev.32.tgz",
-      "integrity": "sha512-x3vFnPp3khjgAv2wAetd2xx94HTmDkeX2eyesCcQFCRbSExtUdxAdCezFWtHriYzonk3mjwZRjN6ypQWK8Fwmg=="
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/feature-flags-contract/-/feature-flags-contract-0.25.2.tgz",
+      "integrity": "sha512-boM7lGgUmwu1p7B6MMl3uA+su368ibCraoaExi3kAKPKfimbToYaMF3un+WD+qe/ja8Au1P1gcEkiFZlzoskDg=="
     },
     "@dashevo/grpc-common": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.25.0-dev.32.tgz",
-      "integrity": "sha512-yopYborud2ByA+tHHeFKiNQf0ezRPvDr/+KATqUeZ66p5DYISoJbOVp+SxBo85LenU1ksUEzro440WJ3Tqo54g==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.25.2.tgz",
+      "integrity": "sha512-M3KgMpBC0hhbwcZp7PkB4mOblqtliNZ25IKHlBoyE82oAQDvRDYRrs1Yzry5twSyJ8cgORKHbGOP/ROdcs74ZA==",
       "requires": {
         "@dashevo/protobufjs": "6.10.5",
         "@grpc/grpc-js": "^1.3.7",
@@ -6059,9 +6158,9 @@
       }
     },
     "@dashevo/masternode-reward-shares-contract": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-0.25.0-dev.32.tgz",
-      "integrity": "sha512-y+ulCaJJIc4D/2RfUi0N5Z1VJimyoUq5qhMOmbb9FQnwaHvOouaMIfSF5+mAgMZi9SZcjSApeJaQQhgi7pVTQA=="
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/masternode-reward-shares-contract/-/masternode-reward-shares-contract-0.25.2.tgz",
+      "integrity": "sha512-grfJoO2UsPx5Va5quWheZa/rNi2tcXu4vVpt/YhUKepkzeg5Yon873e5+HffxBg12BS7gxI+2PAwUrOqq7OovQ=="
     },
     "@dashevo/protobufjs": {
       "version": "6.10.5",
@@ -6096,14 +6195,14 @@
       }
     },
     "@dashevo/wallet-lib": {
-      "version": "7.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-7.25.0-dev.32.tgz",
-      "integrity": "sha512-TqfeV6xILk77Sh+9emMucGtL43TwKKXtDY7TsnK6Kji+lF/W2B1ZhXihWqis0ANCaZpGKEQJGE764DXAuPnzpw==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-7.25.2.tgz",
+      "integrity": "sha512-3SeDgy7TEswhQ84ni7khGu6utUCzCKzt0PekyTQRNAI/I6dsrfpSz/D/XYRNdhl+MLpOxz8FKlWP550spuviQQ==",
       "requires": {
-        "@dashevo/dapi-client": "0.25.0-dev.32",
+        "@dashevo/dapi-client": "0.25.2",
         "@dashevo/dashcore-lib": "~0.20.9",
-        "@dashevo/grpc-common": "0.25.0-dev.32",
-        "@dashevo/wasm-dpp": "0.25.0-dev.32",
+        "@dashevo/grpc-common": "0.25.2",
+        "@dashevo/wasm-dpp": "0.25.2",
         "@yarnpkg/pnpify": "^4.0.0-rc.42",
         "cbor": "^8.0.0",
         "crypto-js": "^4.0.0",
@@ -6114,9 +6213,9 @@
       }
     },
     "@dashevo/wasm-dpp": {
-      "version": "0.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-0.25.0-dev.32.tgz",
-      "integrity": "sha512-q6t/K4pLXC0faCmOKKGwssNE9t28FLx0MuT2omAXeiMVXdRwi1feL/zcm41gbbqeaOhumKYQd/93Lb6Yl0PWxQ==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-dpp/-/wasm-dpp-0.25.2.tgz",
+      "integrity": "sha512-+EECBDbdhmKFMqTcYic0BkbS9VPTK3coyjBbYK/PNwOs6+FZDPkXj751ntlUpbRf+lzG8b1JHrS7rWg2ej1h3w==",
       "requires": {
         "@dashevo/bls": "~1.2.9",
         "bs58": "^4.0.1",
@@ -6190,9 +6289,9 @@
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.4.tgz",
-      "integrity": "sha512-oEnzYiDuEsBydZBtP84BkpduLsE1nSAO4KrhTLHRzNrIQE647fhchmosTQsJdCo8X9zBBt+l5+fNk+m/yCFJ/Q==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.5.tgz",
+      "integrity": "sha512-iouYNlPxRAwZ2XboDT+OfRKHuaKHiqjB5VFYZ0NFrHkbEF+AV3muIUY9olQsp8uxU4VvRCMiRk9ftzFDGb61aw==",
       "requires": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -6210,9 +6309,12 @@
           }
         },
         "@types/node": {
-          "version": "20.8.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.0.tgz",
-          "integrity": "sha512-LzcWltT83s1bthcvjBmiBvGJiiUe84NWRHkw+ZV6Fr41z2FbIzvc815dk2nQ3RAKMuN2fkenM/z3Xv2QzEpYxQ=="
+          "version": "20.8.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
+          "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+          "requires": {
+            "undici-types": "~5.25.1"
+          }
         },
         "cliui": {
           "version": "8.0.1",
@@ -6305,11 +6407,11 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "requires": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       }
     },
     "@jsdevtools/ono": {
@@ -6395,9 +6497,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@sinclair/typebox": {
-      "version": "0.25.24",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "@sindresorhus/is": {
       "version": "4.6.0",
@@ -6443,9 +6545,9 @@
       }
     },
     "@types/estree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+      "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
     },
     "@types/http-cache-semantics": {
       "version": "4.0.2",
@@ -6453,9 +6555,9 @@
       "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw=="
     },
     "@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -6477,9 +6579,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/minimist": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.3.tgz",
+      "integrity": "sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A=="
     },
     "@types/node": {
       "version": "12.20.55",
@@ -6487,9 +6589,9 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
+      "integrity": "sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A=="
     },
     "@types/responselike": {
       "version": "1.0.1",
@@ -6515,17 +6617,17 @@
       "integrity": "sha512-6tOUG+nVHn0cJbVp25JFayS5UE6+xlbcNF9Lo9mU7U0zk3zeUShZied4YEQZjy1JBF043FSkdXw8YkUJuVtB5g=="
     },
     "@yarnpkg/core": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.0.0-rc.52.tgz",
-      "integrity": "sha512-qzFPXsRWMdgUNZYPl5kLhYQbGnnyfAnC/TDIsAeR0Nt9rLkq/cCXRA5aRgDejAHZJzJeB1XjncuR4C9B+LcBbg==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.0.0-rc.53.tgz",
+      "integrity": "sha512-juQC2CCUJE6xu/fpIWrviFzjZO87sxTu9T4C79g2UIjtC2A5mOx35nlk3VcennA41nG8VGqpttbE2YQtuzvpvg==",
       "requires": {
         "@arcanis/slice-ansi": "^1.1.1",
         "@types/semver": "^7.1.0",
         "@types/treeify": "^1.0.0",
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
-        "@yarnpkg/libzip": "^3.0.0-rc.52",
-        "@yarnpkg/parsers": "^3.0.0-rc.52",
-        "@yarnpkg/shell": "^4.0.0-rc.52",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
+        "@yarnpkg/libzip": "^3.0.0-rc.53",
+        "@yarnpkg/parsers": "^3.0.0-rc.53",
+        "@yarnpkg/shell": "^4.0.0-rc.53",
         "camelcase": "^5.3.1",
         "chalk": "^3.0.0",
         "ci-info": "^3.2.0",
@@ -6593,77 +6695,77 @@
       }
     },
     "@yarnpkg/fslib": {
-      "version": "3.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-3.0.0-rc.52.tgz",
-      "integrity": "sha512-zPyVCOzWCxQUe41AYyS8lTDXhg1hAB8XQ49sT7JFW8cU/8wPVa/YAHwcQ210uiKI9P7PsjK0a35jmc7V40Feuw==",
+      "version": "3.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-3.0.0-rc.53.tgz",
+      "integrity": "sha512-raT6iG2MgCulPF/f0UHv3EdXAIXi/5ZtQCT5IHsDdpn7VrhusA8c7Y9WnD03Od2lfXj4C8kNnLoB0OXM9rLmRg==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@yarnpkg/libzip": {
-      "version": "3.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-3.0.0-rc.52.tgz",
-      "integrity": "sha512-RCxm4a1m/Hn2QzSm0+xgyy975pTQnamV+Knu3U/2WX9SSTzytY+tH1PECrLaK7bHiGG9etP3yFdk8fJXADu86g==",
+      "version": "3.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-3.0.0-rc.53.tgz",
+      "integrity": "sha512-dzSkQDg5KMqdC8PE3p57Qr6auIjWGbAP6k+M6gCLOho9zOpmzRGNXJHqN3sqFN43WxPmIZ65faY3yDXDgxHqNg==",
       "requires": {
         "@types/emscripten": "^1.39.6",
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
         "tslib": "^2.4.0"
       }
     },
     "@yarnpkg/nm": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/nm/-/nm-4.0.0-rc.52.tgz",
-      "integrity": "sha512-2Wgu9apCWRdhV3fKXAAc3opmTikkZbmsCFs0TR6yozisVayc2yAETlL+AMZ8l9xmw1RBH1dOItmvfDLx1c+++A==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/nm/-/nm-4.0.0-rc.53.tgz",
+      "integrity": "sha512-W1tdoJF2CKUQJ6YoaUQ+NT2yGOFMsGNdxyqRrHzm3xV22RNIuNm2p3Gr2cjTu13OfstJj9i87aMJiyxbagLxCQ==",
       "requires": {
-        "@yarnpkg/core": "^4.0.0-rc.52",
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
-        "@yarnpkg/pnp": "^4.0.0-rc.52"
+        "@yarnpkg/core": "^4.0.0-rc.53",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
+        "@yarnpkg/pnp": "^4.0.0-rc.53"
       }
     },
     "@yarnpkg/parsers": {
-      "version": "3.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.52.tgz",
-      "integrity": "sha512-b1V4J/tQ8Hj0NalU6EXcYhQcgJqVEz2CgKkoO3suZe7HJlZqrFD2Q9+1vBNbsXAaLqHGVcF0JwRyTRhMT3MJkg==",
+      "version": "3.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.53.tgz",
+      "integrity": "sha512-kprOp3hV9l7B9oqjgTQIM04mmEaYBYcccUXVIM1NFFf10HqnD9joTfZ1cAqx9lpccWzgUnHkrhVwhhlGjPzyIw==",
       "requires": {
         "js-yaml": "^3.10.0",
         "tslib": "^2.4.0"
       }
     },
     "@yarnpkg/pnp": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-4.0.0-rc.52.tgz",
-      "integrity": "sha512-ihUs4QdFc4LGqozxxlAQSjk4z4bt1xnWLTPcZ2gv6tyVv6TAeA7hMVinFiJsp9WMFxARPB20Q+72cAZ0C7jJIg==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnp/-/pnp-4.0.0-rc.53.tgz",
+      "integrity": "sha512-qTn/F/pMRjOggAWcF2Fbwub3BvBKFQJoDC8jv7N4RQOdtUPhMUPq/PQ/iwVEb0Owed+Pt23WKM0CHvED63lLBA==",
       "requires": {
         "@types/node": "^18.17.15",
-        "@yarnpkg/fslib": "^3.0.0-rc.52"
+        "@yarnpkg/fslib": "^3.0.0-rc.53"
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.18.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.1.tgz",
-          "integrity": "sha512-3G42sxmm0fF2+Vtb9TJQpnjmP+uKlWvFa8KoEGquh4gqRmoUG/N0ufuhikw6HEsdG2G2oIKhog1GCTfz9v5NdQ=="
+          "version": "18.18.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.4.tgz",
+          "integrity": "sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ=="
         }
       }
     },
     "@yarnpkg/pnpify": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/pnpify/-/pnpify-4.0.0-rc.52.tgz",
-      "integrity": "sha512-huNVHozWCsYwUV/Ts0pFEUVmkqeFCK2tWRWc5gJxlTqf8LLhZ7C8Tm/CqN/qxta6n/blqrFX8JNhB035RZ+MAw==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/pnpify/-/pnpify-4.0.0-rc.53.tgz",
+      "integrity": "sha512-RZ2yl4Ko+Wb+YIfjmukTwZ0GH436GEuTntXS91s49Jl/C6wZZJ0ve6n8PDd7Wwf2E2ubsDgotlgiv3MrdesSsw==",
       "requires": {
-        "@yarnpkg/core": "^4.0.0-rc.52",
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
-        "@yarnpkg/nm": "^4.0.0-rc.52",
+        "@yarnpkg/core": "^4.0.0-rc.53",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
+        "@yarnpkg/nm": "^4.0.0-rc.53",
         "clipanion": "^4.0.0-rc.2",
         "tslib": "^2.4.0"
       }
     },
     "@yarnpkg/shell": {
-      "version": "4.0.0-rc.52",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/shell/-/shell-4.0.0-rc.52.tgz",
-      "integrity": "sha512-ydSqKU0fFzYoR6mSYr34EM9p5dH7sP2aaMidpRLe5k3RuqykqzIakewcg1hsyvkNsgLOAc1HSbBk2IX9u45RlA==",
+      "version": "4.0.0-rc.53",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/shell/-/shell-4.0.0-rc.53.tgz",
+      "integrity": "sha512-Jjr9ljA8bBGNawQJGVClgR+g/UtuXv47F2gRMiGMYXtyvQpQBC7JHNilIS9dd7y8k6e5AV+JKUPnOOKJd1+EjA==",
       "requires": {
-        "@yarnpkg/fslib": "^3.0.0-rc.52",
-        "@yarnpkg/parsers": "^3.0.0-rc.52",
+        "@yarnpkg/fslib": "^3.0.0-rc.53",
+        "@yarnpkg/parsers": "^3.0.0-rc.53",
         "chalk": "^3.0.0",
         "clipanion": "^4.0.0-rc.2",
         "cross-spawn": "7.0.3",
@@ -6750,9 +6852,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.6.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -6937,9 +7039,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -7048,9 +7150,9 @@
       }
     },
     "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
     },
     "callsites": {
       "version": "3.1.0",
@@ -7071,6 +7173,13 @@
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
+      },
+      "dependencies": {
+        "quick-lru": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+          "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+        }
       }
     },
     "cbor": {
@@ -7159,9 +7268,9 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "ci-info": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -7292,21 +7401,21 @@
       "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "dash": {
-      "version": "3.25.0-dev.32",
-      "resolved": "https://registry.npmjs.org/dash/-/dash-3.25.0-dev.32.tgz",
-      "integrity": "sha512-Phj7sX38VL95vtFtcmvP2x5xEYn3B1QHFrYWvsyC1AWXALvwhBKbrHNA8LL9/Z6CM7QpFmOHHlRpzobGk2MpDA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/dash/-/dash-3.25.2.tgz",
+      "integrity": "sha512-sckKpCcHmfPNhvnSHRBbTd1y2tYsoPCXj5zUnBl6Ajlw68rNpwp/T35Ms0HjOHiuXX3NvtFfIQC3282BSOqHlQ==",
       "requires": {
         "@dashevo/bls": "~1.2.9",
-        "@dashevo/dapi-client": "0.25.0-dev.32",
-        "@dashevo/dapi-grpc": "0.25.0-dev.32",
+        "@dashevo/dapi-client": "0.25.2",
+        "@dashevo/dapi-grpc": "0.25.2",
         "@dashevo/dashcore-lib": "~0.20.9",
-        "@dashevo/dashpay-contract": "0.25.0-dev.32",
-        "@dashevo/dpns-contract": "0.25.0-dev.32",
-        "@dashevo/dpp": "0.25.0-dev.32",
-        "@dashevo/grpc-common": "0.25.0-dev.32",
-        "@dashevo/masternode-reward-shares-contract": "0.25.0-dev.32",
-        "@dashevo/wallet-lib": "7.25.0-dev.32",
-        "@dashevo/wasm-dpp": "0.25.0-dev.32",
+        "@dashevo/dashpay-contract": "0.25.2",
+        "@dashevo/dpns-contract": "0.25.2",
+        "@dashevo/dpp": "0.25.2",
+        "@dashevo/grpc-common": "0.25.2",
+        "@dashevo/masternode-reward-shares-contract": "0.25.2",
+        "@dashevo/wallet-lib": "7.25.2",
+        "@dashevo/wasm-dpp": "0.25.2",
         "bs58": "^4.0.1",
         "node-inspect-extracted": "^1.0.8",
         "winston": "^3.2.1"
@@ -7411,9 +7520,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA=="
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -7483,13 +7592,6 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
-        }
       }
     },
     "es-abstract": {
@@ -7864,9 +7966,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -7969,9 +8071,9 @@
       }
     },
     "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
     },
     "fs-minipass": {
       "version": "2.1.0",
@@ -8271,13 +8373,6 @@
       "requires": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
-      },
-      "dependencies": {
-        "quick-lru": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
-        }
       }
     },
     "ieee754": {
@@ -8359,9 +8454,9 @@
       }
     },
     "is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -8538,20 +8633,20 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "jest-diff": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
-      "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.4.3",
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.5.0"
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       }
     },
     "jest-get-type": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
-      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg=="
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -8597,7 +8692,7 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
         },
         "fast-json-patch": {
           "version": "2.2.1",
@@ -8631,9 +8726,9 @@
       }
     },
     "keyv": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "requires": {
         "json-buffer": "3.0.1"
       }
@@ -8751,12 +8846,19 @@
         "ms": "^2.1.1",
         "safe-stable-stringify": "^2.3.1",
         "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "@colors/colors": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+          "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
+        }
       }
     },
     "long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "loupe": {
       "version": "2.3.6",
@@ -9288,11 +9390,11 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "requires": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       }
@@ -9318,9 +9420,12 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "20.8.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.0.tgz",
-          "integrity": "sha512-LzcWltT83s1bthcvjBmiBvGJiiUe84NWRHkw+ZV6Fr41z2FbIzvc815dk2nQ3RAKMuN2fkenM/z3Xv2QzEpYxQ=="
+          "version": "20.8.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
+          "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+          "requires": {
+            "undici-types": "~5.25.1"
+          }
         },
         "long": {
           "version": "4.0.0",
@@ -9354,9 +9459,9 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -9400,9 +9505,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         },
         "type-fest": {
           "version": "0.6.0",
@@ -9462,9 +9567,9 @@
       }
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -9604,9 +9709,9 @@
       "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
     },
     "semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -9664,6 +9769,13 @@
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "requires": {
         "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
       }
     },
     "slash": {
@@ -9695,14 +9807,14 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w=="
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
+      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw=="
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -9988,6 +10100,11 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+    },
     "unorm": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
@@ -10074,11 +10191,11 @@
       }
     },
     "winston": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
-      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+      "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
       "requires": {
-        "@colors/colors": "1.5.0",
+        "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-tutorial-testing",
-  "version": "0.25.0-dev",
+  "version": "0.25.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -11,8 +11,8 @@
   "author": "thephez",
   "license": "MIT",
   "dependencies": {
-    "@dashevo/wasm-dpp": "^0.25.0-dev.32",
-    "dash": "^3.25.0-dev.32"
+    "@dashevo/wasm-dpp": "^0.25.2",
+    "dash": "^3.25.2"
   },
   "devDependencies": {
     "chai": "^4.3.10",

--- a/test/queryTest.js
+++ b/test/queryTest.js
@@ -16,10 +16,10 @@ const network = process.env.NETWORK;
 // eslint-disable-next-line prefer-const
 let selectedNode =
   goodNodes.goodNodes[Math.floor(Math.random() * goodNodes.goodNodes.length)];
-const documentId = '7AKCoKkMYnhWp9shHZ8icu68ofs6Jxu9TpTPo76sRVu2'; // DPNS domain document ID for identityId
-const identityId = '9RAA5K7qvLgQxitiopxuzVgKE8HmeSDhBzBEQTmwpV8o'; // Identity ID for an identityName (e.g. RT-First-00000)
-const identityName = ['RT-First-00000', 'RT-First-00000-alias'];
-const startsWithString = 'RT-';
+const documentId = 'A7EPNJ1MYFKWEU2Dn2oprpA9dUaRE5zs8r8wDiMeiFcp'; // DPNS domain document ID for identityId
+const identityId = 'D4XykQwuzdNuLLVBbpKLo3VMumuQKKGKFGRYsj5KnMnQ'; // Identity ID for an identityName (e.g. RT-First-00000)
+const identityName = ['DQ-Test-00000', 'DQ-Test-00000-backup'];
+const startsWithString = 'DQ-';
 
 let sdkClient;
 let limit = 1;

--- a/test/test.js
+++ b/test/test.js
@@ -25,7 +25,7 @@ const {
 dotenv.config();
 const mnemonic = process.env.WALLET_MNEMONIC;
 const newIdentityBalance = 9999000; // ~ minimum credit balance of new identity
-const initialName = 'RT-First-00000'; // Used to make query tests easier
+const initialName = 'DQ-Test-00000'; // Used to make docs query tests easier
 const syncStartHeight = process.env.SYNC_START_HEIGHT;
 const network = process.env.NETWORK;
 // eslint-disable-next-line prefer-const
@@ -235,7 +235,7 @@ describe(`Tutorial Code Tests (${new Date().toLocaleTimeString()})`, function su
       if (retrievedName === null) {
         name = initialName;
       } else {
-        name = `RT-${faker.name.firstName()}-${faker.datatype.number()}`;
+        name = `DQ-${faker.name.firstName()}-${faker.datatype.number()}`;
       }
 
       const registeredName = await tutorials.registerName(
@@ -254,7 +254,7 @@ describe(`Tutorial Code Tests (${new Date().toLocaleTimeString()})`, function su
         console.log('\t Skipping the test. Expected identity to be defined.');
         return this.skip();
       }
-      const alias = `${name}-alias`;
+      const alias = `${name}-backup`;
 
       const registeredAlias = await tutorials.registerAlias(
         sdkClient,


### PR DESCRIPTION
Platform 0.25 modified DPNS normalized labels to include additional rules. Modified the code to avoid complicating the query tests.